### PR TITLE
Fix Window keymap overriding command palette

### DIFF
--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,4 +1,4 @@
 [{
-  "keys": ["ctrl+shift+p"],
+  "keys": ["alt+shift+p"],
   "command": "polymer"
 }]


### PR DESCRIPTION
On Windows Ctrl+Shift+P is the main Sublime command palette, so this key binding basically breaks Sublime.

Also:
Ctrl+Alt+P is the project quick switcher.
Ctrl+Alt+Shift+P is the binding to show the current scope under cursor.

Alt+Shift+P doesn't seem to have any conflicts on my configuration.